### PR TITLE
Fixing broken Markdown table formatting in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ This repository is supplied by OMB for the CPIC Community. It's purpose is to ac
 |  Target Date for [XSD **Plus** Candidate] (v2.0.0)  |  July 13, 2018 (Tentative) |
 |  Final Guidance  and [A-11]  |  Late June 2018 (Tentative) |
 |  2020 UAT Server Delivered with Integrated Validations |  July 20, 2018 (Tentative) |
-  Publish XSD  &  XSD **Plus** (v2.0.x)    |  July 9, 2018 (Tentative) |
+|  Publish XSD  &  XSD **Plus** (v2.0.x)    |  July 9, 2018 (Tentative) |
 |  Publish Final XSD  &  XSD **Plus** (v2.0.x)    |  July 16, 2018 (Tentative) |
 |  Draft IT Portfolio Pre-submission  |  August 20, 2018 (Tentative) |
 |  Open 2020 UAT Server Delivered with Complete Integrated Validations |  August 7, 2018 (Tentative)  |


### PR DESCRIPTION
GitHub's Markdown parser is intelligent enough to fix this when it displays the README, but I'm trying to use the README to pull the schedule into our CPIC documentation site and the broken formatting is causing issues.